### PR TITLE
Remove max-nested-callback

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -124,7 +124,6 @@ module.exports = {
 		'complexity': [2, 10],
 		'max-params': [2, 5],
 		'max-depth': [2, 5],
-		'max-nested-callbacks': [2, 5],
 		'max-statements': [2, 25]
 	}
 };


### PR DESCRIPTION
max-nested-callback complicates unit tests.

e.g 

```
describe(()=> {
  describe(()=> {
     it(()=> {
          // already on callback 3
     })
  });
});
```

I don't think nested callback check is needed since we do PR for the most things and we already have a sane style.
