### PR TITLE
Enable valid-jsdoc to prevent invalid and incomplete JSDoc comments.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -95,6 +95,14 @@ module.exports = {
 		'complexity': [2, 10],
 		'max-params': [2, 5],
 		'max-depth': [2, 5],
-		'max-statements': [2, 25]
+		'max-statements': [2, 25],
+		'valid-jsdoc': ['error', {
+			'requireParamDescription': false,
+			'requireReturnDescription': false,
+			'requireReturn': false,
+			'prefer': {
+				'returns': 'return'
+			}
+		}]
 	}
 };


### PR DESCRIPTION
Here's a list of the reported errors from ASS and DrEdition API:

```
/Users/patrik/Code/ass/lib/error.js
   3:1  error  Missing JSDoc for parameter 'message'     valid-jsdoc
  14:1  error  Missing JSDoc for parameter 'message'     valid-jsdoc
  14:1  error  Missing JSDoc for parameter 'statusCode'  valid-jsdoc
  26:1  error  Missing JSDoc for parameter 'message'     valid-jsdoc
  37:1  error  Missing JSDoc for parameter 'message'     valid-jsdoc

/Users/patrik/Code/ass/lib/image/abstract.js
  46:1  error  Unexpected @return tag; function has no return statement  valid-jsdoc
  54:1  error  Unexpected @return tag; function has no return statement  valid-jsdoc
  62:1  error  Unexpected @return tag; function has no return statement  valid-jsdoc
  70:1  error  Unexpected @return tag; function has no return statement  valid-jsdoc

/Users/patrik/Code/ass/lib/logger.js
  30:1  error  Missing JSDoc @return for function  valid-jsdoc
  30:1  error  Missing JSDoc for parameter 'enu'   valid-jsdoc
  44:1  error  Missing JSDoc for parameter 'opts'  valid-jsdoc

/Users/patrik/Code/ass/lib/search/index.js
  7:1  error  Missing JSDoc for parameter 'opts'  valid-jsdoc

/Users/patrik/Code/ass/routes/admin.js
   92:1  error  Missing JSDoc @return for function  valid-jsdoc
  116:1  error  Missing JSDoc @return for function  valid-jsdoc

/Users/patrik/Code/ass/routes/file.js
   33:1  error  Missing JSDoc for parameter 'next'  valid-jsdoc
   96:1  error  Missing JSDoc for parameter 'next'  valid-jsdoc
  137:1  error  Missing JSDoc for parameter 'next'  valid-jsdoc
  150:1  error  Missing JSDoc for parameter 'next'  valid-jsdoc
  244:1  error  Missing JSDoc for parameter 'next'  valid-jsdoc
  262:1  error  Missing JSDoc for parameter 'next'  valid-jsdoc

/Users/patrik/Code/ass/routes/helper.js
  96:1  error  Missing JSDoc for parameter 'message'  valid-jsdoc

/Users/patrik/Code/ass/routes/image.js
   30:1  error  Expected JSDoc for 'next' but found 'opts'  valid-jsdoc
   97:1  error  Missing JSDoc @return for function          valid-jsdoc
   97:1  error  Missing JSDoc for parameter 'next'          valid-jsdoc
  114:1  error  Missing JSDoc @return for function          valid-jsdoc
  114:1  error  Missing JSDoc for parameter 'next'          valid-jsdoc
  160:1  error  Missing JSDoc for parameter 'next'          valid-jsdoc

/Users/patrik/Code/ass/routes/middleware/auth.js
   12:1  error  Expected JSDoc for 'req' but found 'app'  valid-jsdoc
   12:1  error  Missing JSDoc for parameter 'res'         valid-jsdoc
   12:1  error  Missing JSDoc for parameter 'next'        valid-jsdoc
   44:1  error  Missing JSDoc @return for function        valid-jsdoc
   70:1  error  Missing JSDoc @return for function        valid-jsdoc
  107:1  error  Missing JSDoc @return for function        valid-jsdoc

/Users/patrik/Code/ass/routes/middleware/graceful.js
  6:1  error  Missing JSDoc @return for function            valid-jsdoc
  6:1  error  Expected JSDoc for 'app' but found 'servers'  valid-jsdoc

/Users/patrik/Code/ass/routes/middleware/robots.js
  3:1  error  Missing JSDoc @return for function  valid-jsdoc

✖ 37 problems (37 errors, 0 warnings)
```

```
/Users/patrik/Code/aptoma/dredition-api/src/lib/auth/apikey.js
  6:1  error  Missing JSDoc parameter type for 'key'  valid-jsdoc
  6:1  error  Missing JSDoc parameter type for 'cb'   valid-jsdoc
  6:1  error  Missing JSDoc @return for function      valid-jsdoc

/Users/patrik/Code/aptoma/dredition-api/src/lib/auth/jwt.js
  10:1  error  Missing JSDoc @return for function  valid-jsdoc
  48:1  error  Missing JSDoc @return for function  valid-jsdoc

/Users/patrik/Code/aptoma/dredition-api/src/lib/prerequisites/index.js
   6:1  error  Missing JSDoc parameter type for 'req'    valid-jsdoc
   6:1  error  Missing JSDoc parameter type for 'reply'  valid-jsdoc
   6:1  error  Use @return instead                       valid-jsdoc
  40:1  error  Missing JSDoc parameter type for 'req'    valid-jsdoc
  40:1  error  Missing JSDoc parameter type for 'reply'  valid-jsdoc
  40:1  error  Use @return instead                       valid-jsdoc

/Users/patrik/Code/aptoma/dredition-api/src/models/apikey.js
  31:1  error  Use @return instead  valid-jsdoc

/Users/patrik/Code/aptoma/dredition-api/src/models/edition.js
  83:1  error  Use @return instead  valid-jsdoc

/Users/patrik/Code/aptoma/dredition-api/src/models/plugins/output.js
  4:1  error  Missing JSDoc @return for function  valid-jsdoc

/Users/patrik/Code/aptoma/dredition-api/src/models/product.js
  47:1  error  Use @return instead  valid-jsdoc

/Users/patrik/Code/aptoma/dredition-api/src/models/published-edition.js
  62:1  error  Use @return instead  valid-jsdoc

/Users/patrik/Code/aptoma/dredition-api/src/models/user.js
   71:1  error  Use @return instead                          valid-jsdoc
  104:1  error  Use @return instead                          valid-jsdoc
  114:1  error  Missing JSDoc parameter type for 'password'  valid-jsdoc
  114:1  error  Use @return instead                          valid-jsdoc

/Users/patrik/Code/aptoma/dredition-api/src/models/validations/index.js
  10:1  error  Use @return instead  valid-jsdoc
  34:1  error  Use @return instead  valid-jsdoc

/Users/patrik/Code/aptoma/dredition-api/src/plugins/acl/acl.js
  87:1  error  Use @return instead  valid-jsdoc

/Users/patrik/Code/aptoma/dredition-api/src/plugins/jsonapi/index.js
   99:1  error  Missing JSDoc @return for function       valid-jsdoc
  133:1  error  Use @return instead                      valid-jsdoc
  181:1  error  Use @return instead                      valid-jsdoc
  197:1  error  Missing JSDoc parameter type for 'type'  valid-jsdoc
  197:1  error  Missing JSDoc parameter type for 'data'  valid-jsdoc
  197:1  error  Use @return instead                      valid-jsdoc

/Users/patrik/Code/aptoma/dredition-api/src/routes/account/prerequisites.js
  14:1  error  Missing JSDoc parameter type for 'req'    valid-jsdoc
  14:1  error  Missing JSDoc parameter type for 'reply'  valid-jsdoc
  14:1  error  Use @return instead                       valid-jsdoc

/Users/patrik/Code/aptoma/dredition-api/src/routes/content-source/handlers.js
  43:1  error  Missing JSDoc parameter type for 'item'  valid-jsdoc
  43:1  error  Use @return instead                      valid-jsdoc

/Users/patrik/Code/aptoma/dredition-api/src/routes/edition/lib/publish.js
  67:1  error  Missing JSDoc for parameter 'req'  valid-jsdoc

/Users/patrik/Code/aptoma/dredition-api/src/routes/edition/lib/search.js
  115:1  error  Expected JSDoc for 'defaults' but found 'default'  valid-jsdoc

/Users/patrik/Code/aptoma/dredition-api/src/routes/teams/prerequisites.js
  6:1  error  Missing JSDoc parameter type for 'req'    valid-jsdoc
  6:1  error  Missing JSDoc parameter type for 'reply'  valid-jsdoc
  6:1  error  Use @return instead                       valid-jsdoc

/Users/patrik/Code/aptoma/dredition-api/src/routes/transform/handlers.js
  5:1  error  Missing JSDoc parameter type for 'reply'  valid-jsdoc

/Users/patrik/Code/aptoma/dredition-api/src/routes/transform/prerequisites.js
  49:1  error  Missing JSDoc parameter type for 'req'    valid-jsdoc
  49:1  error  Missing JSDoc parameter type for 'reply'  valid-jsdoc
  49:1  error  Use @return instead                       valid-jsdoc

/Users/patrik/Code/aptoma/dredition-api/src/routes/transform/transform.js
  159:1  error  Missing JSDoc parameter type for 'groupItemsField'  valid-jsdoc
  159:1  error  Use @return instead                                 valid-jsdoc

/Users/patrik/Code/aptoma/dredition-api/src/server.js
  95:1  error  Missing JSDoc for parameter 'err'  valid-jsdoc

✖ 46 problems (46 errors, 0 warnings)
```
