### PR TITLE
Fix valid-jsdoc error level

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -131,7 +131,7 @@ module.exports = {
 		'max-params': [2, 5],
 		'max-depth': [2, 5],
 		'max-statements': [2, 25],
-		'valid-jsdoc': ['error', {
+		'valid-jsdoc': [2, {
 			'requireParamDescription': false,
 			'requireReturnDescription': false,
 			'requireReturn': false,


### PR DESCRIPTION
ESlint 4.2.0 gives the following error:

```
Error: @aptoma/eslint-config:
	Configuration for rule "valid-jsdoc" is invalid:
	Severity should be one of the following: 0 = off, 1 = warning, 2 = error (you passed "error").

```