### PR TITLE
Support eslint 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 
 node_js:
-  - 4
+  - 20

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,11 @@
+'use strict';
+const aptoma = require('./lib');
+module.exports = [
+	aptoma,
+	{
+		languageOptions: {
+			ecmaVersion: 2022,
+			sourceType: 'commonjs'
+		}
+	}
+];

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,13 +1,6 @@
 'use strict';
 
 module.exports = {
-	parserOptions: {
-		ecmaVersion: 6,
-		ecmaFeatures: {
-			globalReturn: false
-		}
-	},
-
 	rules: {
 		'linebreak-style': [2, 'unix'],
 		'eol-last': [2],
@@ -130,14 +123,6 @@ module.exports = {
 		'complexity': [2, 10],
 		'max-params': [2, 5],
 		'max-depth': [2, 5],
-		'max-statements': [2, 25],
-		'valid-jsdoc': [2, {
-			'requireParamDescription': false,
-			'requireReturnDescription': false,
-			'requireReturn': false,
-			'prefer': {
-				'returns': 'return'
-			}
-		}]
+		'max-statements': [2, 25]
 	}
 };

--- a/package.json
+++ b/package.json
@@ -4,18 +4,11 @@
   "description": "Aptoma eslint configuration",
   "main": "lib/index.js",
   "scripts": {
-    "lint": "eslint --ext '.js' lib",
+    "lint": "eslint lib",
     "test": "npm run lint",
     "release": "npm run test && release-it -n -i patch",
     "release:minor": "npm run test && release-it -n -i minor",
     "release:major": "npm run test && release-it -n -i major"
-  },
-  "eslintConfig": {
-    "extends": "./lib/index.js",
-    "env": {
-      "node": true,
-      "es6": true
-    }
   },
   "repository": {
     "type": "git",
@@ -32,7 +25,7 @@
   },
   "homepage": "https://github.com/aptoma/eslint-config#readme",
   "devDependencies": {
-    "eslint": "^4.0.0",
+    "eslint": "^9.0.0",
     "release-it": "^2.4.3"
   }
 }


### PR DESCRIPTION
Breaking changes.

Language options is no longer set in this config, this is something we generally set per project anyway.
valid-jsdoc removed, no longer available in eslint 9, use [eslint-jsdoc-plugin](https://www.npmjs.com/package/eslint-plugin-jsdoc) instead.